### PR TITLE
Remove the interfaces without implementation.

### DIFF
--- a/include/nng/mqtt/mqtt_client.h
+++ b/include/nng/mqtt/mqtt_client.h
@@ -557,7 +557,6 @@ NNG_DECL int nng_mqtt_unsubscribe_async(
     nng_mqtt_client *, nng_mqtt_topic *sbs, size_t count, property *pl);
 NNG_DECL int nng_mqtt_disconnect(nng_socket *, uint8_t, property *);
 // as with other ctx based methods, we use the aio form exclusively
-NNG_DECL int nng_mqtt_ctx_subscribe(nng_ctx *, const char *, nng_aio *, ...);
 
 typedef struct nng_mqtt_sqlite_option nng_mqtt_sqlite_option;
 

--- a/include/nng/mqtt/mqtt_quic.h
+++ b/include/nng/mqtt/mqtt_quic.h
@@ -61,8 +61,8 @@ NNG_DECL int nng_mqtt_quic_set_msg_send_cb(
     nng_socket *, int (*cb)(void *, void *), void *arg);
 NNG_DECL int nng_mqtt_quic_ack_callback_set(
     nng_socket *sock, void (*cb)(void *), void *arg);
-NNG_DECL int nng_mqtt_quic_set_config(
-    nng_socket *sock, void *node);
+//NNG_DECL int nng_mqtt_quic_set_config(
+//    nng_socket *sock, void *node);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Which will cause warnings when building and errors when building pynng-mqtt (FFI)