### PR TITLE
Added library alias in demo CMake files, did not build.

### DIFF
--- a/demo/mqtt/CMakeLists.txt
+++ b/demo/mqtt/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(nng CONFIG REQUIRED)
 find_package(Threads)
 
 add_executable(mqtt_client mqtt_client.c)
-target_link_libraries(mqtt_client nng)
+target_link_libraries(mqtt_client nng::nng)
 target_link_libraries(mqtt_client ${CMAKE_THREAD_LIBS_INIT})
 
 if(NNG_ENABLE_TLS)

--- a/demo/mqttv5/CMakeLists.txt
+++ b/demo/mqttv5/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(nng CONFIG REQUIRED)
 find_package(Threads)
 
 add_executable(mqttv5_client mqttv5_client.c)
-target_link_libraries(mqttv5_client nng)
+target_link_libraries(mqttv5_client nng::nng)
 target_link_libraries(mqttv5_client ${CMAKE_THREAD_LIBS_INIT})
 
 if(NNG_ENABLE_TLS)

--- a/demo/quic_mqtt/CMakeLists.txt
+++ b/demo/quic_mqtt/CMakeLists.txt
@@ -25,7 +25,7 @@ if(OPENSSL_FOUND)
     target_link_libraries(quic_client OpenSSL::Crypto OpenSSL::SSL)
 endif()
 
-target_link_libraries(quic_client nng msquic pthread)
+target_link_libraries(quic_client nng::nng msquic pthread)
 target_compile_definitions(quic_client PRIVATE NNG_ELIDE_DEPRECATED)
 
 if (NNG_ENABLE_SQLITE)

--- a/demo/quic_mqttv5/CMakeLists.txt
+++ b/demo/quic_mqttv5/CMakeLists.txt
@@ -25,7 +25,7 @@ if(OPENSSL_FOUND)
     target_link_libraries(quic_client_v5 OpenSSL::Crypto OpenSSL::SSL)
 endif()
 
-target_link_libraries(quic_client_v5 nng msquic pthread)
+target_link_libraries(quic_client_v5 nng::nng msquic pthread)
 target_compile_definitions(quic_client_v5 PRIVATE NNG_ELIDE_DEPRECATED)
 
 if (NNG_ENABLE_SQLITE)


### PR DESCRIPTION
fixes #201 Can't build some of the demo projects

Updated the CMakeLists.txt file in the demo projects. 
"nng::nng" is now used instead of "nng" in target_link_libraries.
