### PR TITLE
Fix warning: operation on *header may be undefined

### DIFF
--- a/src/mqtt/transport/tcp/mqtt_tcp.c
+++ b/src/mqtt/transport/tcp/mqtt_tcp.c
@@ -884,15 +884,15 @@ mqtt_tcptran_pipe_send_start(mqtt_tcptran_pipe *p)
 	msg = nni_aio_get_msg(aio);
 
 	if (msg != NULL && p->proto == MQTT_PROTOCOL_VERSION_v5) {
-		uint8_t *header = nni_msg_header(msg);
-		if ((*header & 0XF0) == CMD_PUBLISH) {
+		uint8_t header = *((uint8_t *)nni_msg_header(msg));
+		if ((header & 0XF0) == CMD_PUBLISH) {
 			// check max qos
 			uint8_t qos = nni_mqtt_msg_get_publish_qos(msg);
 			if (qos > 0)
 				p->sndmax --;
 			if (qos > p->qosmax) {
-				p->qosmax == 1? (*header &= 0XF9) & (*header |= 0X02): NNI_ARG_UNUSED(*header);
-				p->qosmax == 0? *header &= 0XF9:*header;
+				p->qosmax == 1? (header &= 0XF9) & (header |= 0X02): NNI_ARG_UNUSED(header);
+				p->qosmax == 0? header &= 0XF9:header;
 			}
 
 		}

--- a/src/mqtt/transport/tls/mqtt_tls.c
+++ b/src/mqtt/transport/tls/mqtt_tls.c
@@ -852,15 +852,15 @@ mqtts_tcptran_pipe_send_start(mqtts_tcptran_pipe *p)
 	msg = nni_aio_get_msg(aio);
 
 	if (msg != NULL && p->proto == MQTT_PROTOCOL_VERSION_v5) {
-		uint8_t *header = nni_msg_header(msg);
-		if ((*header & 0XF0) == CMD_PUBLISH) {
+		uint8_t header = *((uint8_t *)nni_msg_header(msg));
+		if ((header & 0XF0) == CMD_PUBLISH) {
 			// check max qos
 			uint8_t qos = nni_mqtt_msg_get_publish_qos(msg);
 			if (qos > 0)
 				p->sndmax --;
 			if (qos > p->qosmax) {
-				p->qosmax == 1? (*header &= 0XF9) & (*header |= 0X02):*header;
-				p->qosmax == 0? *header &= 0XF9:*header;
+				p->qosmax == 1? (header &= 0XF9) & (header |= 0X02):header;
+				p->qosmax == 0? header &= 0XF9:header;
 			}
 
 		}


### PR DESCRIPTION
Modified the expression nni_msg_header(msg) to obtain the message header as a single uint8_t value using *((uint8_t *)nni_msg_header(msg)). This avoids potential undefined behavior when dereferencing pointers with unknown alignment and volatile attributes.

this is original code build message
-------------------------------------------
/tmp/nng/src/mqtt/transport/tcp/mqtt_tcp.c: In function ‘mqtt_tcptran_pipe_send_start’:
/tmp/nng/src/mqtt/transport/tcp/mqtt_tcp.c:894:78: warning: operation on ‘*header’ may be undefined [-Wsequence-point]
  894 |                                 p->qosmax == 1? (*header &= 0XF9) & (*header |= 0X02): NNI_ARG_UNUSED(*header);
