### PR TITLE
allow alternate build directory for quic build

### DIFF
--- a/src/supplemental/quic/CMakeLists.txt
+++ b/src/supplemental/quic/CMakeLists.txt
@@ -28,9 +28,9 @@ if (NNG_ENABLE_QUIC)
         nng_link_libraries(ws2_32)
     endif()
 
-    nng_link_libraries("${CMAKE_SOURCE_DIR}/build/_deps/opensslquic-build/openssl/lib/libssl.a")
-    nng_link_libraries("${CMAKE_SOURCE_DIR}/build/_deps/opensslquic-build/openssl/lib/libcrypto.a")
-    nng_include_directories(${CMAKE_SOURCE_DIR}/build/_deps/opensslquic-build/openssl/include)
+    nng_link_libraries("${CMAKE_BINARY_DIR}/_deps/opensslquic-build/openssl/lib/libssl.a")
+    nng_link_libraries("${CMAKE_BINARY_DIR}/_deps/opensslquic-build/openssl/lib/libcrypto.a")
+    nng_include_directories(${CMAKE_BINARY_DIR}/_deps/opensslquic-build/openssl/include)
 
     nng_include_directories(${INTERNAL_MSQUIC_INCLUDE_DIR})
     


### PR DESCRIPTION
Currently if `NNG_ENABLE_QUIC` is set to on, CMake expects to be invoked from a directory called "build". This means that when cmake is invoked with a different build directory (as is often the case with other build runners) then it breaks. This fixes that so that it uses the original cmake invocation directory, wherever it is.