### PR TITLE
Only set certificate file credentials when files are provided

### DIFF
--- a/src/supplemental/quic/quic_api.c
+++ b/src/supplemental/quic/quic_api.c
@@ -270,23 +270,27 @@ there:
 		char *key_path  = node->tls.keyfile;
 		char *password  = node->tls.key_password;
 
-		if (password) {
-			QUIC_CERTIFICATE_FILE_PROTECTED *CertFile =
-			    (QUIC_CERTIFICATE_FILE_PROTECTED *) malloc(sizeof(QUIC_CERTIFICATE_FILE_PROTECTED));
-			CertFile->CertificateFile           = cert_path;
-			CertFile->PrivateKeyFile            = key_path;
-			CertFile->PrivateKeyPassword        = password;
-			CredConfig.CertificateFileProtected = CertFile;
-			CredConfig.Type =
-			    QUIC_CREDENTIAL_TYPE_CERTIFICATE_FILE_PROTECTED;
-		} else {
-			QUIC_CERTIFICATE_FILE *CertFile =
-			    (QUIC_CERTIFICATE_FILE_PROTECTED *) malloc(sizeof(QUIC_CERTIFICATE_FILE_PROTECTED));
-			CertFile->CertificateFile  = cert_path;
-			CertFile->PrivateKeyFile   = key_path;
-			CredConfig.CertificateFile = CertFile;
-			CredConfig.Type =
-			    QUIC_CREDENTIAL_TYPE_CERTIFICATE_FILE;
+		// Only setup certificate files if we have actual paths (not empty strings)
+		if (cert_path && strlen(cert_path) > 0 && key_path && strlen(key_path) > 0) {
+			if (password) {
+				QUIC_CERTIFICATE_FILE_PROTECTED *CertFile =
+				    (QUIC_CERTIFICATE_FILE_PROTECTED *) malloc(sizeof(QUIC_CERTIFICATE_FILE_PROTECTED));
+				CertFile->CertificateFile           = cert_path;
+				CertFile->PrivateKeyFile            = key_path;
+				CertFile->PrivateKeyPassword        = password;
+				CredConfig.CertificateFileProtected = CertFile;
+				CredConfig.Type =
+				    QUIC_CREDENTIAL_TYPE_CERTIFICATE_FILE_PROTECTED;
+			} else {
+				QUIC_CERTIFICATE_FILE *CertFile =
+				    (QUIC_CERTIFICATE_FILE_PROTECTED *) malloc(sizeof(QUIC_CERTIFICATE_FILE_PROTECTED));
+				CertFile->CertificateFile  = cert_path;
+				CertFile->PrivateKeyFile   = key_path;
+				CredConfig.CertificateFile = CertFile;
+				CredConfig.Type =
+				    QUIC_CREDENTIAL_TYPE_CERTIFICATE_FILE;
+			}
+			CredConfig.Flags |= QUIC_CREDENTIAL_FLAG_INDICATE_CERTIFICATE_RECEIVED;
 		}
 
 		BOOLEAN verify = (node->tls.verify_peer == true ? 1 : 0);
@@ -298,9 +302,6 @@ there:
 			CredConfig.Flags |= QUIC_CREDENTIAL_FLAG_INDICATE_CERTIFICATE_RECEIVED;
 			CredConfig.Flags |= QUIC_CREDENTIAL_FLAG_NO_CERTIFICATE_VALIDATION;
 		}
-
-		CredConfig.Type = QUIC_CREDENTIAL_TYPE_CERTIFICATE_FILE;
-		CredConfig.Flags |= QUIC_CREDENTIAL_FLAG_INDICATE_CERTIFICATE_RECEIVED;
 	} else {
 		CredConfig.Flags |= QUIC_CREDENTIAL_FLAG_NO_CERTIFICATE_VALIDATION;
 		log_warn("No quic TLS/SSL credentials was specified.");


### PR DESCRIPTION
## Problem

I'm using `quic_load_sdk_config` like so:

```
memset(&_quicConfig, 0, sizeof(_quicConfig));
_quicConfig.tls.enable = true;  // Enable TLS for secure QUIC
_quicConfig.tls.cafile = strdup("./mqtt-server.pem");  // CA certificate file for server verification
_quicConfig.tls.certfile = strdup("");  // Empty - no client certificate needed
_quicConfig.tls.keyfile = strdup("");   // Empty - no client private key needed
_quicConfig.tls.key_password = strdup("");  // No password needed
_quicConfig.tls.verify_peer = true;
_quicConfig.tls.set_fail = false;
...
```

This fails for me with error -1.

It turns out that the `quic_load_sdk_config()` function in src/supplemental/quic/quic_api.c unconditionally sets
`QUIC_CREDENTIAL_TYPE_CERTIFICATE_FILE` and `QUIC_CREDENTIAL_FLAG_INDICATE_CERTIFICATE_RECEIVED` when
TLS is enabled, even when no client certificate files are provided (empty certfile and keyfile
strings).

This doesn't seem to match the [msquic API spec](https://github.com/microsoft/msquic/blob/main/docs/api/QUIC_CREDENTIAL_CONFIG.md#members) which requires:
- `QUIC_CREDENTIAL_TYPE_NONE` for client-only scenarios without client certificates
- `QUIC_CREDENTIAL_TYPE_CERTIFICATE_FILE` only when actual certificate files are provided

The causes MsQuic->ConfigurationLoadCredential() to fail with error (-268435457) for a (presumably?) legitimate client-only TLS configurations where only server certificate verification is needed.

## Solution

- Add conditional check to only set up certificate file credentials when certfile and keyfile
contain non-empty paths
- Keep `QUIC_CREDENTIAL_TYPE_NONE` (set at initialization) for client-only scenarios with empty
certificate paths
- Move `QUIC_CREDENTIAL_FLAG_INDICATE_CERTIFICATE_RECEIVED` flag inside the certificate file
conditional block
- Remove the unconditional credential type override that was breaking client-only configurations

## Testing

Fix resolves `ConfigurationLoadCredential` failures for client-only QUIC TLS configuration that I'm trying to use.

## Question

Is this a valid use case and I hit a bug, or am I doing this all wrong?